### PR TITLE
CFE-1037: Fix issues pertaining to DNSNameResolver controller

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -18,7 +18,7 @@ COPY pkg/ pkg/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# was called. For example, if we call make image-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -91,11 +91,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: image-build
-image-build: ## Build docker image with the manager.
+image-build: ## Build container image with the manager.
 	$(CONTAINER_TOOL) build -t ${IMG} .
 
-.PHONY: docker-push
-docker-push: ## Push docker image with the manager.
+.PHONY: image-push
+image-push: ## Push container image with the manager.
 	$(CONTAINER_TOOL) push ${IMG}
 
 .PHONY: build-installer

--- a/operator/README.md
+++ b/operator/README.md
@@ -13,9 +13,12 @@ To test the unmanaged DNSNameResolver controller, the operator runs another cont
 watches the DNSNameResolver CRD and starts the DNSNameResolver controller.
 
 Kindly provide correct values for the following arguments using the `args` field of the `manager`
-container in the [`manager.yaml`](./config/manager/manager.yaml) when deploying the operator:
+container in the [`manager.yaml`](./config/manager/manager.yaml) when deploying the operator
+OR in the [`manager_auth_proxy_patch.yaml`](./config/default/manager_auth_proxy_patch.yaml)
+if `make deploy` is used to deploy the operator:
 - `coredns-namespace`
 - `coredns-service-name`
+- `coredns-port`
 - `dns-name-resolver-namespace`
 
 ## Getting Started
@@ -30,7 +33,7 @@ container in the [`manager.yaml`](./config/manager/manager.yaml) when deploying 
 **Build and push your image to the location specified by `IMG`:**
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/operator:tag
+make image-build image-push IMG=<some-registry>/operator:tag
 ```
 
 **NOTE:** This image ought to be published in the personal registry you specified. 
@@ -54,7 +57,7 @@ make deploy IMG=<some-registry>/operator:tag
 ### To Uninstall
 ```
 
-**UnDeploy the operator from the cluster:**
+**Undeploy the operator from the cluster:**
 
 ```sh
 make undeploy

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -64,6 +64,7 @@ func main() {
 		enableHTTP2              bool
 		coreDNSNamespace         string
 		coreDNSServieName        string
+		coreDNSPort              string
 		dnsNameResolverNamespace string
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -77,6 +78,7 @@ func main() {
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
 	flag.StringVar(&coreDNSNamespace, "coredns-namespace", "kube-system", "The namespace of the CoreDNS resources.")
 	flag.StringVar(&coreDNSServieName, "coredns-service-name", "kube-dns", "The name of the CoreDNS service.")
+	flag.StringVar(&coreDNSPort, "coredns-port", "53", "The port on which the CoreDNS pods are listening.")
 	flag.StringVar(&dnsNameResolverNamespace, "dns-name-resolver-namespace", "ovn-kubernetes",
 		"The namespace to watch for the DNSNameResolver objects.")
 	opts := zap.Options{
@@ -134,6 +136,7 @@ func main() {
 		dnsnameresolver.NewUnmanaged(mgr, dnsnameresolver.Config{
 			OperandNamespace:         coreDNSNamespace,
 			ServiceName:              coreDNSServieName,
+			DNSPort:                  coreDNSPort,
 			DNSNameResolverNamespace: dnsNameResolverNamespace,
 		})
 	if err != nil {

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: operator-system
+namespace: dnsnameresolver-operator
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: operator-
+namePrefix: dnsnameresolver-operator-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/operator/config/default/manager_auth_proxy_patch.yaml
@@ -37,3 +37,7 @@ spec:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
         - "--leader-elect"
+        - --coredns-namespace=openshift-dns
+        - --coredns-service-name=dns-default
+        - --dns-name-resolver-namespace=openshift-ovn-kubernetes
+        - --coredns-port=5353

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -38,8 +38,7 @@ spec:
     spec:
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
+      # It is considered best practice to support multiple architectures.
       # affinity:
       #   nodeAffinity:
       #     requiredDuringSchedulingIgnoredDuringExecution:

--- a/operator/config/rbac/role.yaml
+++ b/operator/config/rbac/role.yaml
@@ -30,6 +30,7 @@ rules:
   resources:
   - dnsnameresolvers
   verbs:
+  - get
   - list
   - watch
 
@@ -39,6 +40,8 @@ rules:
   - dnsnameresolvers/status
   verbs:
   - update
+  - get
+  - patch
 
 - apiGroups:
   - discovery.k8s.io

--- a/operator/controller/dnsnameresolver/controller.go
+++ b/operator/controller/dnsnameresolver/controller.go
@@ -127,7 +127,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		// Check if the DNSNameResolver resource is deleted. If so, delete DNS names matching the DNSNameResolver resource
 		// from the resolver.
 		if errors.IsNotFound(err) {
-			r.resolver.Delete(request.Name)
+			r.resolver.DeleteResolvedName(dnsDetails{objName: request.Name})
 			return reconcile.Result{}, nil
 		}
 
@@ -161,12 +161,22 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// event then this will ensure that the resolver sends the resolution request
 	// for the DNS name, so that the status of the object gets updated with the
 	// corresponding IP addresses.
-	r.resolver.Add(dnsName, []ocpnetworkv1alpha1.DNSNameResolverResolvedAddress{}, matchesRegular, request.Name)
+	r.resolver.AddResolvedName(dnsDetails{
+		dnsName:           dnsName,
+		resolvedAddresses: []ocpnetworkv1alpha1.DNSNameResolverResolvedAddress{},
+		matchesRegular:    matchesRegular,
+		objName:           request.Name,
+	})
 
 	// Iterate through each of the resolved names matching the DNS name and add
 	// them to the resolver along with the current IP addresses.
 	for _, resolvedName := range dnsNameResolver.Status.ResolvedNames {
-		r.resolver.Add(string(resolvedName.DNSName), resolvedName.ResolvedAddresses, matchesRegular, request.Name)
+		r.resolver.AddResolvedName(dnsDetails{
+			dnsName:           string(resolvedName.DNSName),
+			resolvedAddresses: resolvedName.ResolvedAddresses,
+			matchesRegular:    matchesRegular,
+			objName:           request.Name,
+		})
 	}
 
 	return reconcile.Result{}, nil

--- a/operator/controller/dnsnameresolver/controller.go
+++ b/operator/controller/dnsnameresolver/controller.go
@@ -34,13 +34,12 @@ var (
 type Config struct {
 	OperandNamespace         string
 	ServiceName              string
+	DNSPort                  string
 	DNSNameResolverNamespace string
 }
 
 // reconciler handles the actual DNSNameResolver reconciliation logic in response to events.
 type reconciler struct {
-	config Config
-
 	dnsNameResolverCache cache.Cache
 	client               client.Client
 	resolver             *Resolver
@@ -82,10 +81,9 @@ func NewUnmanaged(mgr manager.Manager, config Config) (controller.Controller, []
 
 	// Initialize the reconciler.
 	reconciler := &reconciler{
-		config:               config,
 		dnsNameResolverCache: dnsNameResolverCache,
 		client:               mgr.GetClient(),
-		resolver:             NewResolver(corednsEndpointsSliceCache, config.ServiceName),
+		resolver:             NewResolver(corednsEndpointsSliceCache, config.DNSPort),
 	}
 
 	// Create an unmanaged controller using the reconciler.


### PR DESCRIPTION
This PR adds the support to provide port on which the CoreDNS is listening on as an input. RBAC permissions are added for getting events related to DNSNameResolver status updates. It also fixes the issue of deadlock condition in the resolver. 