### PR TITLE
OCPBUGS-34918: Bump go version to 1.22 and fix issue with go install

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: rhel-9-release-golang-1.22-openshift-4.17

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/openshift/coredns-ocp-dnsnameresolver
 
-go 1.21
+go 1.22
 
 require (
 	github.com/coredns/caddy v1.1.1

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -180,7 +180,7 @@ define go-install-tool
 set -e; \
 package=$(2)@$(3) ;\
 echo "Downloading $${package}" ;\
-GOBIN=$(LOCALBIN) go install $${package} ;\
+GOBIN=$(LOCALBIN) go install -mod=mod $${package} ;\
 mv "$$(echo "$(1)" | sed "s/-$(3)$$//")" $(1) ;\
 }
 endef


### PR DESCRIPTION
This PR updates the Makefile of DNSNameResolver operator to fix the issue with go install by using `-mod=mod`. The go version of the ocp_dnsnameresolver plugin is also bumped to 1.22 and local CI config for build_root image is added.