### PR TITLE
OCPBUGS-34918: Bump go version to 1.22 in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.21-openshift-4.16 as builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.17 as builder
 WORKDIR /go/src/github.com/openshift/coredns-ocp-dnsnameresolver
 COPY . .
 
 RUN make build-coredns
 
-FROM registry.ci.openshift.org/ocp/4.16:base
+FROM registry.ci.openshift.org/ocp/4.17:base
 COPY --from=builder /go/src/github.com/openshift/coredns-ocp-dnsnameresolver/coredns /usr/bin/
 
 ENTRYPOINT ["/usr/bin/coredns"]

--- a/Dockerfile.upstream
+++ b/Dockerfile.upstream
@@ -1,4 +1,4 @@
-FROM golang:1.21 as builder
+FROM golang:1.22 as builder
 WORKDIR /go/src/github.com/coredns/coredns-ocp-dnsnameresolver
 COPY . .
 


### PR DESCRIPTION
This PR bumps the go version to 1.22 in the Dockerfiles.