### PR TITLE
[release-4.16] OCPBUGS-37080: Checkout specific branch/tag of cloned coredns repo during build

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  name: release
+  namespace: openshift
+  tag: golang-1.21

--- a/hack/build-coredns.sh
+++ b/hack/build-coredns.sh
@@ -10,6 +10,14 @@ set -euo pipefail
 
 PLUGIN_PATH=$(readlink -f "$(dirname "$0")/..")
 
+# Get current branch name. If the current branch name does not match
+# the pattern "release-*", then use master branch.
+BRANCH_TAG=$(git rev-parse --abbrev-ref HEAD)
+if [[ "${BRANCH_TAG}" != release-* ]]
+then
+    BRANCH_TAG="master"
+fi
+
 # Create a temporary directory for cloning coredns repo.
 # The directory will be deleted after the execution of script.
 BASE_PATH=$(mktemp -d)
@@ -20,9 +28,13 @@ COREDNS_URL="https://github.com/openshift/coredns"
 if  [ ! -z "${1-}" ] && [ "${1}" = "upstream" ]
 then
     COREDNS_URL="https://github.com/coredns/coredns"
+    BRANCH_TAG="v$(curl -s https://raw.githubusercontent.com/openshift/coredns/${BRANCH_TAG}/coremain/version.go | grep CoreVersion | grep -Po '\d+\.\d+\.\d+')"
 fi
 echo "Cloning from ${COREDNS_URL}"
 git clone "${COREDNS_URL}"
+cd "${BASE_PATH}"/coredns
+echo "Checking out branch/tag ${BRANCH_TAG}"
+git checkout ${BRANCH_TAG}
 
 # Add the "ocp_dnsnameresolver" plugin to the cloned coredns repo.
 "${PLUGIN_PATH}"/hack/add-plugin.sh "${BASE_PATH}"/coredns "${PLUGIN_PATH}"


### PR DESCRIPTION
Manual backport of #12. Adds `.ci-operator.yaml` file for adding local ci config.